### PR TITLE
feat: 实现公共用户状态组件并集成到create页面

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,5 +13,6 @@ declare module '@vue/runtime-core' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SocialFeedContent: typeof import('./components/SocialFeedContent.vue')['default']
+    UserStatusCard: typeof import('./components/UserStatusCard.vue')['default']
   }
 }

--- a/src/components/UserStatusCard.vue
+++ b/src/components/UserStatusCard.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { useUserStore } from '@/store/user';
+
+interface Props {
+  theme?: 'green' | 'wechat' | 'blue';
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  theme: 'wechat'
+});
+
+// 用户状态管理
+const userStore = useUserStore();
+const { loggedIn, userInfo } = storeToRefs(userStore);
+
+// 主题颜色配置
+const themeColors = {
+  wechat: '#07c160',  // 微信绿 - neighbor页面
+  green: '#28a745',   // Bootstrap绿 - task页面  
+  blue: '#007aff'     // 蓝色 - create页面
+};
+
+const currentColor = themeColors[props.theme];
+</script>
+
+<template>
+  <view v-if="loggedIn" class="section user-status-section" :style="{ borderLeftColor: currentColor }">
+    <view class="status-header">
+      <text class="section-title">👤 用户状态</text>
+      <text class="status-badge logged-in" :style="{ backgroundColor: currentColor }">已登录</text>
+    </view>
+    <view class="user-info">
+      <text class="user-name">{{ userInfo.first_name }} {{ userInfo.last_name }}</text>
+      <text class="user-detail">{{ userInfo.email }}</text>
+      <text v-if="userInfo.community_name" class="user-community" :style="{ color: currentColor }">🏠 {{ userInfo.community_name }}</text>
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.section {
+  margin-bottom: 16px;
+  padding: 16px;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.user-status-section {
+  border-left: 4px solid;
+  background: #f0f9f4;
+}
+
+.status-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-weight: bold;
+  font-size: 16px;
+  color: #333;
+}
+
+.status-badge {
+  padding: 4px 12px;
+  border-radius: 16px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.status-badge.logged-in {
+  color: white;
+}
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.user-name {
+  font-weight: 600;
+  font-size: 16px;
+  color: #333;
+}
+
+.user-detail {
+  font-size: 14px;
+  color: #666;
+}
+
+.user-community {
+  font-size: 13px;
+  font-weight: 500;
+}
+</style>

--- a/src/pages/create/create.vue
+++ b/src/pages/create/create.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts" name="create">
 import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useUserStore } from '@/store/user';
+import UserStatusCard from '../../components/UserStatusCard.vue';
+
+// 用户状态管理
+const userStore = useUserStore();
+const { loggedIn, userInfo } = storeToRefs(userStore);
 
 // --- 登录与通用状态 ---
 const apiBaseUrl = ref('/api');
@@ -201,8 +208,11 @@ function clearForm() {
 
 <template>
   <view class="create-poc">
-    <!-- 登录区 -->
-    <view class="section">
+    <!-- 用户状态显示 -->
+    <UserStatusCard theme="blue" />
+
+    <!-- 登录区 - 仅在未登录时显示 -->
+    <view v-if="!loggedIn" class="section">
       <view class="form-title">🔐 登录认证</view>
       <view class="row">
         <text class="label">邮箱 *</text>

--- a/src/pages/neighbor/neighbor.vue
+++ b/src/pages/neighbor/neighbor.vue
@@ -3,6 +3,7 @@ import { computed, ref, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUserStore } from '@/store/user';
 import SocialFeedContent from '../../components/SocialFeedContent.vue';
+import UserStatusCard from '../../components/UserStatusCard.vue';
 
 /**
  * 业主圈页面 - 获取业主圈帖子
@@ -444,17 +445,7 @@ function fallbackCopyTextToClipboard(text: string) {
     </view>
 
     <!-- 用户登录状态显示 -->
-    <view v-if="loggedIn" class="section user-status-section">
-      <view class="status-header">
-        <text class="section-title">👤 用户状态</text>
-        <text class="status-badge logged-in">已登录</text>
-      </view>
-      <view class="user-info">
-        <text class="user-name">{{ userInfo.first_name }} {{ userInfo.last_name }}</text>
-        <text class="user-detail">{{ userInfo.email }}</text>
-        <text v-if="userInfo.community_name" class="user-community">🏠 {{ userInfo.community_name }}</text>
-      </view>
-    </view>
+    <UserStatusCard theme="wechat" />
 
     <!-- 操作区域 - 已登录时隐藏 -->
     <view v-if="!loggedIn" class="section">
@@ -904,46 +895,6 @@ function fallbackCopyTextToClipboard(text: string) {
   color: #999;
 }
 
-/* 用户状态显示 */
-.user-status-section {
-  border-left: 4px solid #07c160;
-  background: #f0f9f4;
-}
-.status-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-}
-.status-badge {
-  padding: 4px 12px;
-  border-radius: 16px;
-  font-size: 12px;
-  font-weight: 500;
-}
-.status-badge.logged-in {
-  background: #07c160;
-  color: white;
-}
-.user-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.user-name {
-  font-weight: 600;
-  font-size: 16px;
-  color: #333;
-}
-.user-detail {
-  font-size: 14px;
-  color: #666;
-}
-.user-community {
-  font-size: 13px;
-  color: #07c160;
-  font-weight: 500;
-}
 
 /* 加载动画 */
 @keyframes pulse {

--- a/src/pages/task/task.vue
+++ b/src/pages/task/task.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUserStore } from '@/store/user';
+import UserStatusCard from '../../components/UserStatusCard.vue';
 
 /**
  * 事项页面 - 获取业主投诉工单数据
@@ -289,17 +290,7 @@ function fallbackCopyTextToClipboard(text: string) {
     </view>
 
     <!-- 用户状态显示 -->
-    <view v-if="loggedIn" class="section user-status-section">
-      <view class="status-header">
-        <text class="section-title">👤 用户状态</text>
-        <text class="status-badge logged-in">已登录</text>
-      </view>
-      <view class="user-info">
-        <text class="user-name">{{ userInfo.first_name }} {{ userInfo.last_name }}</text>
-        <text class="user-detail">{{ userInfo.email }}</text>
-        <text v-if="userInfo.community_name" class="user-community">🏠 {{ userInfo.community_name }}</text>
-      </view>
-    </view>
+    <UserStatusCard theme="green" />
 
     <!-- 操作区域 - 已登录时隐藏 -->
     <view v-if="!loggedIn" class="section">
@@ -425,46 +416,6 @@ function fallbackCopyTextToClipboard(text: string) {
   font-size: 14px;
 }
 
-/* 用户状态显示 */
-.user-status-section {
-  border-left: 4px solid #28a745;
-  background: #f0f9f4;
-}
-.status-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-}
-.status-badge {
-  padding: 4px 12px;
-  border-radius: 16px;
-  font-size: 12px;
-  font-weight: 500;
-}
-.status-badge.logged-in {
-  background: #28a745;
-  color: white;
-}
-.user-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.user-name {
-  font-weight: 600;
-  font-size: 16px;
-  color: #333;
-}
-.user-detail {
-  font-size: 14px;
-  color: #666;
-}
-.user-community {
-  font-size: 13px;
-  color: #28a745;
-  font-weight: 500;
-}
 
 /* 页面标题 */
 .header {


### PR DESCRIPTION
## Summary
- 创建公共用户状态显示组件 UserStatusCard.vue，支持多主题配置
- 重构 neighbor.vue 和 task.vue 使用公共组件
- 集成 create.vue 用户状态管理，实现条件显示逻辑

## 主要变更
### 新增公共组件 UserStatusCard.vue
- 支持主题颜色配置 (wechat/green/blue)  
- 统一用户状态显示逻辑和样式
- 动态绑定主题色到边框、徽章、社区名称

### 重构现有页面
- **neighbor.vue**: 使用 wechat 主题 (微信绿 #07c160)
- **task.vue**: 使用 green 主题 (Bootstrap绿 #28a745)  
- **create.vue**: 新增用户状态管理，使用 blue 主题 (#007aff)

### create.vue 功能增强
- 添加 Pinia 用户状态查询 (loggedIn, userInfo)
- 已登录时显示用户信息卡片，隐藏登录认证区域
- 未登录时显示登录认证区域
- 发布功能保持不变

## Test plan
- [x] 验证三个页面的用户状态显示功能正常
- [x] 确认不同主题颜色显示正确
- [x] 测试已登录/未登录状态的UI切换
- [x] 验证create页面发布功能未受影响

🤖 Generated with [Claude Code](https://claude.ai/code)