### PR TITLE
feat: 隐藏前两个导航标签页，只保留三个页面

### DIFF
--- a/src/pages.json
+++ b/src/pages.json
@@ -1,24 +1,6 @@
 {
   "pages": [
     {
-      "name": "neighbor",
-      "path": "pages/neighbor/neighbor",
-      "style": {
-        "navigationBarTitleText": "邻里",
-        "navigationBarBackgroundColor": "#ffffff",
-        "navigationBarTextStyle": "black"
-      }
-    },
-    {
-      "name": "notice",
-      "path": "pages/notice/notice", 
-      "style": { 
-        "navigationBarTitleText": "公告",
-        "navigationBarBackgroundColor": "#ffffff",
-        "navigationBarTextStyle": "black"
-      }
-    },
-    {
       "name": "create",
       "path": "pages/create/create",
       "style": { 
@@ -97,29 +79,22 @@
     "spacing": "3px",
     "list": [
       {
-        "pagePath": "pages/neighbor/neighbor",
-        "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg"
-      },
-      {
-        "pagePath": "pages/notice/notice",
-        "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg"
-      },
-      {
         "pagePath": "pages/create/create",
         "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg"
+        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "text": "创建"
       },
       {
         "pagePath": "pages/task/task",
         "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg"
+        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "text": "事项"
       },
       {
         "pagePath": "pages/profile/profile",
         "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg"
+        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "text": "我"
       }
     ]
   }

--- a/src/store/navigation.ts
+++ b/src/store/navigation.ts
@@ -19,24 +19,25 @@ export interface TabBarState {
 const useNavigationStore = defineStore(
   'navigation',
   () => {
-    // 定义导航标签页数据
+    // 定义导航标签页数据 - 隐藏前两个页面（邻里和公告）
     const tabs = ref<TabItem[]>([
-      {
-        id: 'neighbor',
-        name: 'neighbor',
-        path: '/pages/neighbor/neighbor',
-        text: '邻里',
-        icon: 'static/icons/neighbor.png',
-        activeIcon: 'static/icons/neighbor-active.png'
-      },
-      {
-        id: 'notice',
-        name: 'notice',
-        path: '/pages/notice/notice',
-        text: '公告',
-        icon: 'static/icons/notice.png',
-        activeIcon: 'static/icons/notice-active.png'
-      },
+      // 注释掉前两个页面，但保留页面代码文件
+      // {
+      //   id: 'neighbor',
+      //   name: 'neighbor',
+      //   path: '/pages/neighbor/neighbor',
+      //   text: '邻里',
+      //   icon: 'static/icons/neighbor.png',
+      //   activeIcon: 'static/icons/neighbor-active.png'
+      // },
+      // {
+      //   id: 'notice',
+      //   name: 'notice',
+      //   path: '/pages/notice/notice',
+      //   text: '公告',
+      //   icon: 'static/icons/notice.png',
+      //   activeIcon: 'static/icons/notice-active.png'
+      // },
       {
         id: 'create',
         name: 'create',


### PR DESCRIPTION
## 修改内容

- 隐藏邻里和公告两个导航标签页
- 只保留创建、事项、我三个页面
- 保留原有页面代码文件，仅从导航中移除
- 修复导航栏显示问题，添加必要的text属性

## 技术实现

1. **修改 navigation store**: 注释掉前两个标签页配置
2. **更新 pages.json**: 
   - 移除前两个 tabBar 项目
   - 为每个标签页添加 text 属性
   - 调整页面顺序，将创建页面设为首页

## 测试

- ✅ 导航栏正常显示3个标签页
- ✅ 页面切换功能正常
- ✅ 原有页面代码完整保留