### PR TITLE
feat: 更新导航栏图标，优化激活状态视觉效果

### DIFF
--- a/src/pages.json
+++ b/src/pages.json
@@ -82,20 +82,20 @@
     "list": [
       {
         "pagePath": "pages/create/create",
-        "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "iconPath": "static/icons/create.svg",
+        "selectedIconPath": "static/icons/create-active.svg",
         "text": "创建"
       },
       {
         "pagePath": "pages/task/task",
-        "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "iconPath": "static/icons/task.svg",
+        "selectedIconPath": "static/icons/task-active.svg",
         "text": "事项"
       },
       {
         "pagePath": "pages/profile/profile",
-        "iconPath": "static/icons/ic--round-house.svg",
-        "selectedIconPath": "static/icons/ic--round-house.svg",
+        "iconPath": "static/icons/profile.svg",
+        "selectedIconPath": "static/icons/profile-active.svg",
         "text": "我"
       }
     ]

--- a/src/static/icons/create-active.svg
+++ b/src/static/icons/create-active.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1AA86C" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" fill="#1AA86C" fill-opacity="0.25"/>
+  <line x1="12" y1="8" x2="12" y2="16"/>
+  <line x1="8" y1="12" x2="16" y2="12"/>
+</svg>

--- a/src/static/icons/create.svg
+++ b/src/static/icons/create.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="12" y1="8" x2="12" y2="16"/>
+  <line x1="8" y1="12" x2="16" y2="12"/>
+</svg>

--- a/src/static/icons/profile-active.svg
+++ b/src/static/icons/profile-active.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1AA86C" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+  <circle cx="12" cy="7" r="4" fill="#1AA86C" fill-opacity="0.25"/>
+</svg>

--- a/src/static/icons/profile.svg
+++ b/src/static/icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+  <circle cx="12" cy="7" r="4"/>
+</svg>

--- a/src/static/icons/task-active.svg
+++ b/src/static/icons/task-active.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1AA86C" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 11l3 3L22 4"/>
+  <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" fill="#1AA86C" fill-opacity="0.25"/>
+</svg>

--- a/src/static/icons/task.svg
+++ b/src/static/icons/task.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 11l3 3L22 4"/>
+  <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+</svg>


### PR DESCRIPTION
## 🎨 更新内容

### 图标替换
- **创建页面**: 使用加号圆圈图标，直观表达新建内容功能
- **事项页面**: 使用勾选清单图标，清晰表达任务管理功能  
- **个人页面**: 使用用户头像图标，明确表达个人中心功能

### 激活状态优化
采用**渐进式填充设计方案**，参考小红书、Instagram等优秀应用的设计模式：
- **线条加粗**: stroke-width从2增加到2.5，提升视觉层次
- **透明填充**: 添加25%透明度的绿色填充，保持图标呼吸感
- **颜色一致**: 使用应用主题绿色(#1AA86C)，保持品牌一致性

### 技术实现
- 使用SVG矢量图标，支持无损缩放
- 更新pages.json配置，替换原有统一图标
- 保持图标清晰度和识别性

### 用户体验提升
- ✅ 每个导航标签页都有专属的语义化图标
- ✅ 激活状态视觉反馈更加精致，不再过于厚重
- ✅ 符合现代应用设计趋势和用户习惯

## 📱 预览效果
新的导航栏图标在普通状态下保持灰色线条风格，激活时呈现绿色加粗线条配合淡绿色填充，既有明显的视觉反馈，又保持了图标的识别性。

## 🔍 测试确认
- [x] 图标正常显示
- [x] 激活状态切换正常
- [x] 颜色主题一致
- [x] 各端兼容性良好